### PR TITLE
Fixed an infinite loop after getting an error in the image generation

### DIFF
--- a/scripts/fabric.py
+++ b/scripts/fabric.py
@@ -461,7 +461,6 @@ class FabricScript(modules.scripts.Script):
             print("[FABRIC] Skipping U-Net forward pass patching")
     
     def postprocess(self, p, processed, *args):
-        print("[FABRIC] Restoring original U-Net forward pass")
         unpatch_unet_forward_pass(p.sd_model.model.diffusion_model)
 
         images = processed.images[processed.index_of_first_image:]

--- a/scripts/patching.py
+++ b/scripts/patching.py
@@ -118,7 +118,7 @@ def patch_unet_forward_pass(p, unet, params):
 
         # save original forward pass
         for module in self.modules():
-            if isinstance(module, BasicTransformerBlock):
+            if isinstance(module, BasicTransformerBlock) and not hasattr(module.attn1, "_fabric_old_forward"):
                 module.attn1._fabric_old_forward = module.attn1.forward
 
         # fix for medvram option
@@ -200,7 +200,7 @@ def patch_unet_forward_pass(p, unet, params):
 
         # restore original pass
         for module in self.modules():
-            if isinstance(module, BasicTransformerBlock):
+            if isinstance(module, BasicTransformerBlock) and hasattr(module.attn1, "_fabric_old_forward"):
                 module.attn1.forward = module.attn1._fabric_old_forward
                 del module.attn1._fabric_old_forward
 

--- a/scripts/patching.py
+++ b/scripts/patching.py
@@ -212,5 +212,6 @@ def patch_unet_forward_pass(p, unet, params):
 
 def unpatch_unet_forward_pass(unet):
     if hasattr(unet, "_fabric_old_forward"):
+        print("[FABRIC] Restoring original U-Net forward pass")
         unet.forward = unet._fabric_old_forward
         del unet._fabric_old_forward


### PR DESCRIPTION
- Fixed an infinite loop after getting an error in the image generation
- Limited the U-Net restoration message to display only when it happens